### PR TITLE
Fix Host enable in ONEv5

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = Net-OpenNebula
-version = 0.308.0
+version = 0.309.0
 author = Jan Gehring <jfried@rexify.org>
 license = Apache_2_0
 copyright_holder = Jan Gehring

--- a/lib/Net/OpenNebula/Host.pm
+++ b/lib/Net/OpenNebula/Host.pm
@@ -31,6 +31,8 @@ Query the Hoststatus of an OpenNebula host.
 
 package Net::OpenNebula::Host;
 
+use version;
+
 use Net::OpenNebula::RPC;
 push our @ISA , qw(Net::OpenNebula::RPC);
 
@@ -70,14 +72,31 @@ sub _enable {
                          );
 }
 
+# Use private _status to enable/disable/offline hyps (since ONE 5.0)
+# status(int): 0 enabled, 1 disabled, 2 offline
+sub _status {
+    my ($self, $status) = @_;
+
+    return $self->_onerpc("status",
+                          [ int => $self->id ],
+                          [ int => $status ],
+                         );
+}
+
 sub enable {
     my $self = shift;
-    return $self->_enable(1);
+    if ($self->{rpc}->version() < version->new('5.0.0')) {
+        return $self->_enable(1);
+    };
+    return $self->_status(0);
 }
 
 sub disable {
     my ($self) = @_;
-    return $self->_enable(0);
+    if ($self->{rpc}->version() < version->new('5.0.0')) {
+        return $self->_enable(0);
+    };
+    return $self->_status(1);
 }
 
 # Return the state as string

--- a/lib/Net/OpenNebula/Host.pm
+++ b/lib/Net/OpenNebula/Host.pm
@@ -87,16 +87,18 @@ sub enable {
     my $self = shift;
     if ($self->{rpc}->version() < version->new('5.0.0')) {
         return $self->_enable(1);
+    } else {
+        return $self->_status(0);
     };
-    return $self->_status(0);
 }
 
 sub disable {
     my ($self) = @_;
     if ($self->{rpc}->version() < version->new('5.0.0')) {
         return $self->_enable(0);
+    } else {
+        return $self->_status(1);
     };
-    return $self->_status(1);
 }
 
 # Return the state as string


### PR DESCRIPTION
I found that `one.host.enable` is failing with ONEv5 deployments, they have included a new method (`one.host.status`) and a new host status (`offline`). This PR keeps the backwards compatibility with the Quattor component.

More info:
http://docs.opennebula.org/5.2/integration/system_interfaces/api.html#actions-for-hosts-management